### PR TITLE
- add client certificate and client_verify

### DIFF
--- a/templates/virtualhost.conf.j2
+++ b/templates/virtualhost.conf.j2
@@ -57,6 +57,12 @@ server {
 {% if item.tls is defined %}
     ssl_certificate     {{ item.tls.cert }};
     ssl_certificate_key {{ item.tls.key }};
+{% if item.client is defined %}
+    ssl_client_certificate {{ item.tls.client }};
+{% endif %}
+{% if item.client_verify is defined %}
+    ssl_verify_client {{ item.tls.client_verify }}; 
+{% endif %}
 {% endif %}
 {% if item.letsencrypt is defined %}{% if item.letsencrypt %}
     ## letsencrypt validation requirement


### PR DESCRIPTION
Hi uZer,

We need 2 more parameters in the virtualhost.j2 file
ssl_client_certificate (for ssl client certificate authentication)
and 
ssl_verify_client (to indicate if the client certificate is optional or required)

Could you merge the pull request ? 

Thanks